### PR TITLE
Much more friendly to an RPM style build.

### DIFF
--- a/aware.c
+++ b/aware.c
@@ -20,6 +20,9 @@
 #include "Zend/zend_builtin_functions.h"
 #include "ext/standard/php_string.h"
 
+#include <fcntl.h>
+#include <sys/mman.h>
+
 #include "zend.h"
 #include "zend_ini_scanner.h"
 #include "zend_language_scanner.h"

--- a/aware.spec
+++ b/aware.spec
@@ -62,6 +62,17 @@ Requires: %{name} = %{version}-%{release}
 %{name} backend implementation which sends email.
 %endif
 
+### Conditional build for files
+%if %{with files}
+%package files
+Summary: File storage engine for %{name}
+Group:   Web/Applications
+Requires: %{name} = %{version}-%{release}
+
+%description files
+%{name} backend implementation which stores events in files.
+%endif
+
 %prep
 %setup -q -n aware-%{version}
 
@@ -87,6 +98,13 @@ echo "extension=aware.so" > %{buildroot}/%{_sysconfdir}/php.d/aware.ini
 	popd
 %endif
 
+%if %{with files}
+	pushd storage/files
+	/usr/bin/phpize && %configure && %{__make} %{?_smp_mflags}
+	%{__make} install INSTALL_ROOT=%{buildroot}
+	popd
+%endif
+
 
 %clean
 [ "%{buildroot}" != "/" ] && %{__rm} -rf %{buildroot}
@@ -102,6 +120,11 @@ echo "extension=aware.so" > %{buildroot}/%{_sysconfdir}/php.d/aware.ini
 %if %{with email}
 %files email
 %{_libdir}/php/modules/aware-email.so
+%endif
+
+%if %{with files}
+%files files
+%{_libdir}/php/modules/aware-files.so
 %endif
 
 

--- a/aware.spec
+++ b/aware.spec
@@ -24,7 +24,7 @@
 
 
 # Define version and release number
-%define version 0.1.1
+%define version @PACKAGE_VERSION@
 %define release 1
 
 Name:      php-aware

--- a/aware.spec
+++ b/aware.spec
@@ -84,6 +84,39 @@ Requires: %{name} = %{version}-%{release}
 %{name} backend implementation which sends events as SNMP traps.
 %endif
 
+### Conditional build for spread
+%if %{with spread}
+%package spread
+Summary: Spread storage engine for %{name}
+Group:   Web/Applications
+Requires: %{name} = %{version}-%{release}
+
+%description Spread
+%{name} backend implementation which sends events via spread.
+%endif
+
+### Conditional build for stomp
+%if %{with stomp}
+%package stomp
+Summary: Stomp storage engine for %{name}
+Group:   Web/Applications
+Requires: %{name} = %{version}-%{release}
+
+%description stomp
+%{name} backend implementation which sends events via stomp.
+%endif
+
+### Conditional build for zeromq2
+%if %{with zeromq2}
+%package zeromq2
+Summary: zeromq2 storage engine for %{name}
+Group:   Web/Applications
+Requires: %{name} = %{version}-%{release}
+
+%description zeromq2
+%{name} backend implementation which sends events via zeromq2.
+%endif
+
 %prep
 %setup -q -n aware-%{version}
 
@@ -123,6 +156,27 @@ echo "extension=aware.so" > %{buildroot}/%{_sysconfdir}/php.d/aware.ini
 	popd
 %endif
 
+%if %{with spread}
+	pushd storage/spread
+	/usr/bin/phpize && %configure && %{__make} %{?_smp_mflags}
+	%{__make} install INSTALL_ROOT=%{buildroot}
+	popd
+%endif
+
+%if %{with stomp}
+	pushd storage/stomp
+	/usr/bin/phpize && %configure && %{__make} %{?_smp_mflags}
+	%{__make} install INSTALL_ROOT=%{buildroot}
+	popd
+%endif
+
+%if %{with zeromq2}
+	pushd storage/zeromq2
+	/usr/bin/phpize && %configure && %{__make} %{?_smp_mflags}
+	%{__make} install INSTALL_ROOT=%{buildroot}
+	popd
+%endif
+
 
 %clean
 [ "%{buildroot}" != "/" ] && %{__rm} -rf %{buildroot}
@@ -148,6 +202,21 @@ echo "extension=aware.so" > %{buildroot}/%{_sysconfdir}/php.d/aware.ini
 %if %{with snmp}
 %files snmp
 %{_libdir}/php/modules/aware_snmp.so
+%endif
+
+%if %{with spread}
+%files spread
+%{_libdir}/php/modules/aware_spread.so
+%endif
+
+%if %{with stomp}
+%files stomp
+%{_libdir}/php/modules/aware_stomp.so
+%endif
+
+%if %{with zeromq2}
+%files stomp
+%{_libdir}/php/modules/aware_zeromq2.so
 %endif
 
 

--- a/aware.spec
+++ b/aware.spec
@@ -121,7 +121,7 @@ Requires: %{name} = %{version}-%{release}
 %setup -q -n aware-%{version}
 
 %build
-/usr/bin/phpize && %configure && %{__make} %{?_smp_mflags}
+/usr/bin/phpize && %configure -C && %{__make} %{?_smp_mflags}
 
 # Clean the buildroot so that it does not contain any stuff from previous builds
 [ "%{buildroot}" != "/" ] && %{__rm} -rf %{buildroot}
@@ -137,42 +137,42 @@ echo "extension=aware.so" > %{buildroot}/%{_sysconfdir}/php.d/aware.ini
 
 %if %{with email}
 	pushd storage/email
-	/usr/bin/phpize && %configure && %{__make} %{?_smp_mflags}
+	/usr/bin/phpize && cp ../../config.cache . && %configure -C && %{__make} %{?_smp_mflags}
 	%{__make} install INSTALL_ROOT=%{buildroot}
 	popd
 %endif
 
 %if %{with files}
 	pushd storage/files
-	/usr/bin/phpize && %configure && %{__make} %{?_smp_mflags}
+	/usr/bin/phpize && cp ../../config.cache . && %configure -C && %{__make} %{?_smp_mflags}
 	%{__make} install INSTALL_ROOT=%{buildroot}
 	popd
 %endif
 
 %if %{with snmp}
 	pushd storage/snmp
-	/usr/bin/phpize && %configure && %{__make} %{?_smp_mflags}
+	/usr/bin/phpize && cp ../../config.cache . && %configure -C && %{__make} %{?_smp_mflags}
 	%{__make} install INSTALL_ROOT=%{buildroot}
 	popd
 %endif
 
 %if %{with spread}
 	pushd storage/spread
-	/usr/bin/phpize && %configure && %{__make} %{?_smp_mflags}
+	/usr/bin/phpize && cp ../../config.cache . && %configure -C && %{__make} %{?_smp_mflags}
 	%{__make} install INSTALL_ROOT=%{buildroot}
 	popd
 %endif
 
 %if %{with stomp}
 	pushd storage/stomp
-	/usr/bin/phpize && %configure && %{__make} %{?_smp_mflags}
+	/usr/bin/phpize && cp ../../config.cache . && %configure -C && %{__make} %{?_smp_mflags}
 	%{__make} install INSTALL_ROOT=%{buildroot}
 	popd
 %endif
 
 %if %{with zeromq2}
 	pushd storage/zeromq2
-	/usr/bin/phpize && %configure && %{__make} %{?_smp_mflags}
+	/usr/bin/phpize && cp ../../config.cache . && %configure -C && %{__make} %{?_smp_mflags}
 	%{__make} install INSTALL_ROOT=%{buildroot}
 	popd
 %endif

--- a/aware.spec
+++ b/aware.spec
@@ -215,7 +215,7 @@ echo "extension=aware.so" > %{buildroot}/%{_sysconfdir}/php.d/aware.ini
 %endif
 
 %if %{with zeromq2}
-%files stomp
+%files zeromq2
 %{_libdir}/php/modules/aware_zeromq2.so
 %endif
 

--- a/aware.spec
+++ b/aware.spec
@@ -73,6 +73,17 @@ Requires: %{name} = %{version}-%{release}
 %{name} backend implementation which stores events in files.
 %endif
 
+### Conditional build for snmp
+%if %{with snmp}
+%package snmp
+Summary: SNMP storage engine for %{name}
+Group:   Web/Applications
+Requires: %{name} = %{version}-%{release}
+
+%description snmp
+%{name} backend implementation which sends events as SNMP traps.
+%endif
+
 %prep
 %setup -q -n aware-%{version}
 
@@ -105,6 +116,13 @@ echo "extension=aware.so" > %{buildroot}/%{_sysconfdir}/php.d/aware.ini
 	popd
 %endif
 
+%if %{with snmp}
+	pushd storage/snmp
+	/usr/bin/phpize && %configure && %{__make} %{?_smp_mflags}
+	%{__make} install INSTALL_ROOT=%{buildroot}
+	popd
+%endif
+
 
 %clean
 [ "%{buildroot}" != "/" ] && %{__rm} -rf %{buildroot}
@@ -119,12 +137,17 @@ echo "extension=aware.so" > %{buildroot}/%{_sysconfdir}/php.d/aware.ini
 
 %if %{with email}
 %files email
-%{_libdir}/php/modules/aware-email.so
+%{_libdir}/php/modules/aware_email.so
 %endif
 
 %if %{with files}
 %files files
-%{_libdir}/php/modules/aware-files.so
+%{_libdir}/php/modules/aware_files.so
+%endif
+
+%if %{with snmp}
+%files snmp
+%{_libdir}/php/modules/aware_snmp.so
 %endif
 
 

--- a/package.xml
+++ b/package.xml
@@ -48,10 +48,55 @@
    <file name="aware_cache.c" role="src" />
 
    <!-- misc files -->
-   <file name="README.md" role="doc" />
+   <file name="README" role="doc" />
    <file name="EXAMPLE_CONFIG.txt" role="doc" />
    <file name="INSTALL.txt" role="doc" />
    <file name="LICENSE" role="doc" />
+     <dir name="storage">
+	<dir name="email">
+	 <file name="aware_email.c" role="src" />
+	 <file name="config.m4" role="src" />
+	 <file name="php_aware_email.h" role="src" />
+	</dir>
+	<dir name="files">
+	 <file name="aware_files.c" role="src" />
+	 <file name="config.w32" role="src" />
+	 <file name="config.m4" role="src" />
+	 <file name="php_aware_files.h" role="src" />
+	</dir>
+	<dir name="snmp">
+	 <file name="aware_snmp.c" role="src" />
+	 <file name="config.m4" role="src" />
+	 <file name="php_aware_snmp.h" role="src" />
+	</dir>
+	<dir name="spread">
+	 <file name="aware_spread.c" role="src" />
+	 <file name="config.m4" role="src" />
+	 <file name="php_aware_spread.h" role="src" />
+	</dir>
+	<dir name="stomp">
+	 <file name="aware_stomp.c" role="src" />
+	 <file name="config.m4" role="src" />
+	 <file name="config.w32" role="src" />
+	 <file name="php_aware_stomp.h" role="src" />
+	 <file name="aware_stomp_funcs.c" role="src" />
+	 <file name="php_aware_stomp_funcs.h" role="src" />
+	</dir>
+	<dir name="tokyo">
+	 <file name="aware_tokyo.c" role="src" />
+	 <file name="aware_tokyo_cabinet.c" role="src" />
+	 <file name="aware_tokyo_tyrant.c" role="src" />
+	 <file name="php_aware_tokyo.h" role="src" />
+	 <file name="php_aware_tokyo_cabinet.h" role="src" />
+	 <file name="php_aware_tokyo_tyrant.h" role="src" />
+	 <file name="config.m4" role="src" />
+	</dir>
+	<dir name="zeromq2">
+	 <file name="aware_zeromq2.c" role="src" />
+	 <file name="php_aware_zeromq2.h" role="src" />
+	 <file name="config.m4" role="src" />
+	</dir>
+     </dir>
   </dir>
  </contents>
  <dependencies>

--- a/package.xml
+++ b/package.xml
@@ -48,7 +48,7 @@
    <file name="aware_cache.c" role="src" />
 
    <!-- misc files -->
-   <file name="README" role="doc" />
+   <file name="README.md" role="doc" />
    <file name="EXAMPLE_CONFIG.txt" role="doc" />
    <file name="INSTALL.txt" role="doc" />
    <file name="LICENSE" role="doc" />

--- a/storage/email/php_aware_email.h
+++ b/storage/email/php_aware_email.h
@@ -32,8 +32,8 @@
 # include "TSRM.h"
 #endif
 
-#include <ext/aware/php_aware.h>
-#include <ext/aware/php_aware_storage.h>
+#include "../../php_aware.h"
+#include "../../php_aware_storage.h"
 
 ZEND_BEGIN_MODULE_GLOBALS(aware_email)
 	char *to_address;

--- a/storage/files/php_aware_files.h
+++ b/storage/files/php_aware_files.h
@@ -32,8 +32,8 @@
 # include "TSRM.h"
 #endif
 
-#include <ext/aware/php_aware.h>
-#include <ext/aware/php_aware_storage.h>
+#include "../../php_aware.h"
+#include "../../php_aware_storage.h"
 
 ZEND_BEGIN_MODULE_GLOBALS(aware_files)
 	char *storage_path;

--- a/storage/skeleton/php_aware_skeleton.h
+++ b/storage/skeleton/php_aware_skeleton.h
@@ -32,8 +32,8 @@
 # include "TSRM.h"
 #endif
 
-#include <ext/aware/php_aware.h>
-#include <ext/aware/php_aware_storage.h>
+#include "../../php_aware.h"
+#include "../../php_aware_storage.h"
 
 ZEND_BEGIN_MODULE_GLOBALS(aware_skeleton)
 	char *foobar;

--- a/storage/snmp/php_aware_snmp.h
+++ b/storage/snmp/php_aware_snmp.h
@@ -32,8 +32,8 @@
 # include "TSRM.h"
 #endif
 
-#include <ext/aware/php_aware.h>
-#include <ext/aware/php_aware_storage.h>
+#include "../../php_aware.h"
+#include "../../php_aware_storage.h"
 
 #include <net-snmp/net-snmp-config.h>
 #include <net-snmp/net-snmp-includes.h>

--- a/storage/spread/php_aware_spread.h
+++ b/storage/spread/php_aware_spread.h
@@ -32,8 +32,8 @@
 # include "TSRM.h"
 #endif
 
-#include <ext/aware/php_aware.h>
-#include <ext/aware/php_aware_storage.h>
+#include "../../php_aware.h"
+#include "../../php_aware_storage.h"
 
 #include <sp.h>
 

--- a/storage/stomp/php_aware_stomp.h
+++ b/storage/stomp/php_aware_stomp.h
@@ -32,8 +32,8 @@
 # include "TSRM.h"
 #endif
 
-#include <ext/aware/php_aware.h>
-#include <ext/aware/php_aware_storage.h>
+#include "../../php_aware.h"
+#include "../../php_aware_storage.h"
 
 #include "php_aware_stomp_funcs.h"
 

--- a/storage/tokyo/php_aware_tokyo.h
+++ b/storage/tokyo/php_aware_tokyo.h
@@ -28,8 +28,8 @@
 # include "config.h"
 #endif
 
-#include <ext/aware/php_aware.h>
-#include <ext/aware/php_aware_storage.h>
+#include "../../php_aware.h"
+#include "../../php_aware_storage.h"
 
 #include <stdlib.h>
 #include <stdlib.h>

--- a/storage/zeromq2/php_aware_zeromq2.h
+++ b/storage/zeromq2/php_aware_zeromq2.h
@@ -32,8 +32,8 @@
 # include "TSRM.h"
 #endif
 
-#include <ext/aware/php_aware.h>
-#include <ext/aware/php_aware_storage.h>
+#include "../../php_aware.h"
+#include "../../php_aware_storage.h"
 
 #include <zmq.h>
 


### PR DESCRIPTION
Flushed out spec file to build sub packages.
Patched aware.c to use required headers.
Patched all the storage plugins to use relative paths to header files so as to make relative building easier.
Cannot personally test the snmp, stomp, or spread builds.  Can you?
